### PR TITLE
initalized ouath model to asana and main code

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+# Python package dependencies for the backend of the Asana-MCP server.
+fastapi
+pydantic

--- a/backend/src/asana/models/schemas.py
+++ b/backend/src/asana/models/schemas.py
@@ -1,0 +1,29 @@
+# backend/src/asana/schemas.py
+
+from pydantic import BaseModel
+from typing import List, Dict, Any, Optional
+
+class AttachContextRequest(BaseModel):
+    """
+    Payload for attaching a named MCP context to an Asana task.
+    """
+    task_gid: str
+    context_name: str
+
+class AsanaEvent(BaseModel):
+    """
+    A single event delivered via Asana webhook.
+    You can expand these fields as needed.
+    """
+    resource: Dict[str, Any]
+    action: str
+    user: Dict[str, Any]
+    created_at: str
+    parent: Optional[Dict[str, Any]]
+
+class AsanaWebhookPayload(BaseModel):
+    """
+    The full webhook payload from Asana.
+    """
+    events: List[AsanaEvent]
+    # You can add `workspace`, `organization`, etc., as needed.

--- a/backend/src/asana/oauth.py
+++ b/backend/src/asana/oauth.py
@@ -1,0 +1,36 @@
+# backend/src/asana/oauth.py
+
+import httpx
+from pydantic import BaseModel
+
+from ..config import settings
+from ..logging import logger
+
+class AsanaTokenResponse(BaseModel):
+    access_token: str
+    expires_in: int
+    token_type: str
+    refresh_token: str
+
+async def exchange_code_for_token(code: str) -> AsanaTokenResponse:
+    """
+    Exchange the OAuth `code` from Asana for an access + refresh token pair.
+    """
+    token_url = "https://app.asana.com/-/oauth_token"
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": settings.ASANA_CLIENT_ID,
+        "client_secret": settings.ASANA_CLIENT_SECRET,
+        "redirect_uri": settings.ASANA_REDIRECT_URI,
+        "code": code,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(token_url, data=payload)
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        logger.error("OAuth token exchange failed: %s → %s", resp.status_code, resp.text)
+        raise
+
+    data = resp.json()
+    return AsanaTokenResponse(**data)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,0 +1,105 @@
+# backend/src/main.py
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from .asana.oauth import exchange_code_for_token, AsanaTokenResponse
+from .asana.schemas import AttachContextRequest
+from .logging import logger
+
+
+class Settings(BaseSettings):
+    MCP_SERVER_URL: str
+    ASANA_CLIENT_ID: str
+    ASANA_CLIENT_SECRET: str
+    ASANA_REDIRECT_URI: str
+
+    class Config:
+        env_file = ".env"
+        env_prefix = ""
+
+settings = Settings()
+
+logger = logging.getLogger("mcp_asana")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(
+    logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+)
+logger.addHandler(handler)
+
+class HealthCheckResponse(BaseModel):
+    status: str = "ok"
+    mcp_server: str
+
+app = FastAPI(
+    title="MCP ↔ Asana Context-Linker",
+    version="0.1.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception: %s", exc)
+    # If it's an HTTPException, respect its status code
+    if isinstance(exc, HTTPException):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail},
+        )
+    # Otherwise, return 500
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
+
+
+@app.get("/health", response_model=HealthCheckResponse)
+async def health_check():
+    """
+    Simple health check endpoint.
+    Verifies the server is running and can reach the MCP server URL.
+    """
+    # (In a later iteration you might actually ping settings.MCP_SERVER_URL here.)
+    logger.info("Health check requested")
+    return HealthCheckResponse(mcp_server=settings.MCP_SERVER_URL)
+
+
+@app.get(
+    "/asana/oauth/callback",
+    response_model=AsanaTokenResponse,
+    summary="Handle Asana OAuth redirect"
+)
+async def asana_oauth_callback(code: str):
+    """
+    Exchange `code` for an Asana access token.
+    """
+    try:
+        token = await exchange_code_for_token(code)
+    except Exception as e:
+        # exchange_code_for_token already logs the detail
+        raise HTTPException(502, detail="Failed to exchange OAuth code")
+
+    # TODO: persist `token.access_token` & `token.refresh_token` securely
+    logger.info("Obtained Asana tokens for code=%s", code)
+    return token
+
+
+@app.post(
+    "/asana/attach-context",
+    status_code=204,
+    summary="Attach a named MCP context to an Asana task"
+)
+async def attach_context(payload: AttachContextRequest):
+    """
+    Given a task GID and a context name, fetch the context
+    from MCP and post it as a comment on the Asana task.
+    (Implementation to come.)
+    """
+    logger.info("attach-context called: %s", payload.json())
+    # TODO:
+    # 1. fetch context from MCP via your mcpClient
+    # 2. POST to https://app.asana.com/api/1.0/tasks/{task_gid}/stories
+    return JSONResponse(status_code=204)


### PR DESCRIPTION
**Pull Request: Add Asana OAuth Exchange & Request Schemas**

---

### 📋 Overview

This PR introduces the first pieces of our Asana integration backend:

1. **`asana/oauth.py`**

   * Implements `exchange_code_for_token(code: str)` to asynchronously exchange an OAuth code for Asana access/refresh tokens via HTTPX.
   * Defines a Pydantic `AsanaTokenResponse` model for strong typing.
   * Logs and surfaces errors on HTTP failures.
2. **`asana/schemas.py`**

   * Adds `AttachContextRequest` for the `/asana/attach-context` payload.
   * Defines `AsanaEvent` and `AsanaWebhookPayload` for future webhook handling.
3. **`main.py`**

   * Wires the OAuth helper into `GET /asana/oauth/callback`, returning a typed token response or HTTP 502 on failure.
   * Stubs `POST /asana/attach-context` using the new `AttachContextRequest` model.

---

### ✅ What’s Included

* **Async token exchange** with error handling & structured logging
* **Pydantic models** for request/response validation
* **Clean, modular layout** ready for token persistence and MCP call integration

---

### 🔎 Testing & Verification

* Unit tests should cover:

  * Successful and failed HTTPX requests in `exchange_code_for_token`
  * Validation errors for malformed `AttachContextRequest` payloads
* Manual:

  1. Start server (`uvicorn main:app`)
  2. Hit `/asana/oauth/callback?code=TEST` and observe error logging or valid schema response
  3. POST invalid/valid JSON to `/asana/attach-context` and verify 422 vs. 204 responses

---

### 🚀 Next Steps

* Persist tokens securely (DB or vault)
* Implement MCP fetch + Asana comment posting in `attach_context`
* Add webhook receiver endpoint using `AsanaWebhookPayload`
* Factor routes/controllers into separate modules as project grows

---

Please review and let me know if any adjustments are needed!
